### PR TITLE
README: Change BTC Donation Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Copyright (c) 2018, Blur Network</br>
 *See [LICENSE](LICENSE).*<br>
 
 ### Donate to help support Blur:
-**BTC:** 1CeFbUtrqDzp7nvnXotuuARwHPxAXCLb4u <br>
+**BTC:** 19onVUREbP89qu4dYBfVqtGisWaoyWs3BX <br>
 **LTC:** LM2tBw25UMfdjAJbo52tzh5r3R47a1aMeM <br>
 **XMR:** 46MT7yy9mF3Bvk61XmRzirB4wdSkPqNRJ3pwUcRYxj3WWCGLMHD9sE5bNtChnYQiPYiCYDPyXyJGKFG3uT2CbeKWCwnvWLv <br>
 **BLUR:** bL4PdWFk3VVgEGYezGTXigHrsoJ3JGKgxKDi1gHXT7GKTLawFu3WMhu53Gc2KCmxxmCHbR4VEYMQ93PRv8vWgJ8j2mMHVEzLu <br>


### PR DESCRIPTION
BTC Donation Address is now the same as the exchange-listing fund address.